### PR TITLE
Fixed substructure query on umap to use cube indexing

### DIFF
--- a/backend/app/app/api/v2/endpoints/molecule.py
+++ b/backend/app/app/api/v2/endpoints/molecule.py
@@ -141,7 +141,7 @@ def search_molecules(
     sql = text(
         """
         SET LOCAL enable_sort=off;
-        select molecule_id, smiles, molecular_weight, umap[0] as umap1, umap[1] as umap2 from molecule 
+        select molecule_id, smiles, molecular_weight, umap->1 as umap1, umap->2 as umap2 from molecule 
         where mol@>:substructure
         order by morganbv <%> morganbv_fp(mol_from_smiles(:substructure)) 
         offset :offset 


### PR DESCRIPTION
Substructure search was broken because we were using indexing assuming umap was still an array when it had been changed in the DB to the cube type.

- Changed the query to use cube indexing.