### PR TITLE
adds support for searching using SMARTS strings

### DIFF
--- a/frontend/src/pages/SearchHook.js
+++ b/frontend/src/pages/SearchHook.js
@@ -134,6 +134,7 @@ export default function SearchHook () {
 
             setIsLoading(false);
             setIsLoadingMore(false);
+            setValidSmiles(true);
 
           })
 
@@ -157,7 +158,7 @@ export default function SearchHook () {
         <Container maxWidth="lg">
         <h2>Substructure Search</h2>
         <TextField id="search-outline" 
-                  label="Enter a SMILES String to Search" 
+                  label="Enter a SMILES or SMARTS String to Search" 
                   variant="outlined"
                   defaultValue= {searchString} 
                   onChange = { event => setSearch( event.target.value ) }
@@ -171,7 +172,7 @@ export default function SearchHook () {
         <Container sx={{display: 'flex', justifyContent: 'center', my: 3}}>
             <Box sx={{ display: 'flex' }}>
              { isLoading && <CircularProgress sx={{ color: "#ed1c24" }} /> }
-             { !isLoading && !validSmiles  && <Typography>Invalid Smiles String</Typography> }
+             { !isLoading && !validSmiles  && <Typography>Search string is not valid SMILES or SMARTS. Please provide valid SMILES or SMARTS strings.</Typography> }
              { !isLoading && validSmiles && Object.keys(svg_results).length > 0 && 
              <Container> 
                 { dynamicGrid(svg_results)  }


### PR DESCRIPTION
This PR changes the substructure search slightly so that [SMARTS](https://www.daylight.com/dayhtml_tutorials/languages/smarts/smarts_examples.html) strings can be used in addition to SMILES. This is achieved mostly by adding `::qmol` to the substructure search. This is based on one example from [the RDKit documentation](https://www.rdkit.org/docs/Cartridge.html#smarts-based-queries). My tests indicate that it works without changing the results when SMILES are used.

Some other changes are made in this endpoint, like also checking for valid smarts. The `valid_smiles` function will fail for SMARTS strings.

Supporting SMARTS should add a lot of flexibility for substructure searches.

To try this out, try comparing results from SMILES `'C'` (carbon/methyl) to the SMARTS specific to a methyl group (`[CH3]`). You can also try some SMARTS patterns from the page linked above. 

Screenshot for SMARTS search for `[CX3](=O)[OX2H1]` - carboxylic acid, attached.
![substructure_smarts](https://user-images.githubusercontent.com/18010556/226188065-ec80441f-97a8-4903-a8d5-5419e751e0ae.png)
