### PR TITLE
Issues/race conditions neighbors

### DIFF
--- a/backend/app/app/api/v2/endpoints/molecule.py
+++ b/backend/app/app/api/v2/endpoints/molecule.py
@@ -190,6 +190,10 @@ def search_neighbors(
     if molecule_id > max_molecule_id:
         raise HTTPException(status_code=404, detail=f"Molecule with ID supplied not found, the maximum ID is {max_molecule_id}")
     
+    # Check to see if the molecule_id is within range.
+    if molecule_id <= 0:
+        raise HTTPException(status_code=500)
+    
     # Check for valid neighbor type.
     if type not in ["pca", "umap"]:
         raise HTTPException(status_code=400, detail="Invalid neighbor type.")

--- a/frontend/src/pages/Neighbors.js
+++ b/frontend/src/pages/Neighbors.js
@@ -320,9 +320,6 @@ export default function NeighborSearchHook () {
        * Main driver function which loads the neighbors for a molecule requested by the user.
        * 
        */
-        console.log("calling neighbors");
-        console.log("Skip: ", skip);
-        console.log("Search Page: ", searchPage);
         const fetchData = async () => {
             const molecule_data = await NeighborSearch(moleculeid, type, arrayToString(componentArrayForm), interval, skip);
             const svg_data = await retrieveAllSVGs(molecule_data);
@@ -360,10 +357,7 @@ export default function NeighborSearchHook () {
             else {
               setShowGraph(false);
             }
-
-            console.log("Data fetch donezo");
           })
-
     }
 
     // If any parameters change, we must set updatedParameters to true.


### PR DESCRIPTION
In this PR I have attempted to fix the race conditions on the neighbors page using an alternative approach to using am AbortController. The main updates are:

1. Removing useEffect hooks on querying new data on changing parameters. This leads to unexpected results due to the asynchronous nature of the setState and the fact that useEffect hooks trigger on initial load up too (in our current MVP, this means 4 `loadNeighbors()` calls are done right when the page is loaded). Additionally, the react documentation states not use useEffects to orchestrate the dataflow of the application: https://react.dev/reference/react.
2. Using useEffect hooks to see if the correct states are present when calling `loadNeighbors()` on either a new search or loading more. These useEffect hooks will only trigger `loadNeighbors()` when ALL states that need to be updated are the right values (this solves the problem of asynchronous setStates).
3. Disabling buttons when searching. The `load more` and `new search` buttons become unclickable when a new search or loading more data is happening. This prevents consecutive calls and the race conditions.
4. Disabling changing parameters when a search is on going. Even with the previous constraints in place, if you try and search and then change a parameter quickly there is a possibily you can impact the final output.
5. Disabling `load more` buttons when we change parameters. This is an interesting edge case, where if you change a parameter and then click load more instead of search, you will retain the previous search and get a new search and the graph will have 2 different clusters. It is cool but not the intended functionality and so disabling the `load more` buttons when changing parameters will prevent this.

Currently I think it makes sense to prevent changing the max 6 parameters that are involved in the search instead of aborting on every change (changing components, type or molecule) but I want to try and take a stab at adding the AbortController as well. However, when I think about it, on most other website if you search you're not able to modify your entries until the result has been returned or you are sent to another page before the data loads in to prevent re-entry.

I have also left in debugging statements so when you are testing you can see how many times different parts are called and sometimes their states.