### PR TITLE
removes unnecessary useEffect from search page

### DIFF
--- a/frontend/src/pages/SearchHook.js
+++ b/frontend/src/pages/SearchHook.js
@@ -210,16 +210,6 @@ export default function SearchHook () {
         [ searchToggle ] 
     );
 
-    // Update searchString if representation changes
-    useEffect(() => {
-        if (representation === "smiles"){
-            setSearch(smiles);
-        }
-        else if (representation === "SMARTS"){
-            setSearch(SMARTS);
-        }
-      }, [representation]);
-
       const _handleKeyDown = useCallback(
         (event) => {
           if (event.key === "Enter") {


### PR DESCRIPTION
I think the second `useEffect` hook on the search page is no longer necessary because it only sets the representation (SMILES or SMARTS) and this is already being done in the `switchRepresentations` function.