### PR TITLE
Issue/search load more

### DIFF
--- a/frontend/src/pages/SearchHook.js
+++ b/frontend/src/pages/SearchHook.js
@@ -286,7 +286,7 @@ export default function SearchHook () {
              { !isLoading && validSmiles && Object.keys(svg_results).length > 0 && 
              <Container> 
                 { dynamicGrid(svg_results)  }
-                { isLoadingMore ? <CircularProgress sx={{ color: "#ed1c24" }} /> : <ThemeProvider theme={theme}><Button disabled={updatedParameters} variant="contained" style={{backgroundColor: "#ed1c24"}} sx={{ my: 3 }} onClick={ () => loadMore() } >Load More</Button></ThemeProvider> }
+                { isLoadingMore ? <CircularProgress sx={{ color: "#ed1c24" }} /> : <ThemeProvider theme={theme}><Button disabled={updatedParameters} variant="contained" sx={{ my: 3 }} onClick={ () => loadMore() } >Load More</Button></ThemeProvider> }
             </Container>  }
             { !isLoading && validSmiles && Object.keys(svg_results).length==0 && <Typography>No results found for SMILES string.</Typography> } 
             </Box>


### PR DESCRIPTION
In this PR I have limited some unexpected behaviour on the substructure search page. On the neighbors page if you don't prevent the `load more` button from being pressed after making changes to the form, then you will get 2 different clusters on the graph as well as a new set of images below the original set. This translates over to the substructure search page, as you can change the query manually and then scroll down to click load more and get 2 sets of images. I have limited this behaviour in the same way I have limited it on the neighbor search page by disabling the loadmore button when the searchstring has been changed but a new search has not been executed yet.

Here is the issue in action:
![search_loadmore_issue](https://user-images.githubusercontent.com/69454662/232257823-fabaa8f1-ceed-4f97-8bff-ea291e3d449b.gif)

Here is the fix in action:
![search_fix](https://user-images.githubusercontent.com/69454662/232257977-74b004b5-58a0-4e09-a9e2-d26053d945f4.gif)

