### PR TITLE
Bug/neighbor search

### DIFF
--- a/frontend/src/pages/Neighbors.js
+++ b/frontend/src/pages/Neighbors.js
@@ -180,6 +180,7 @@ export default function NeighborSearchHook () {
     function _handleKeyDown(event) {
       if (event.key === "Enter") {
         newSearch();
+        updateGraphComponentProps();
       }
     }
 


### PR DESCRIPTION
In this PR I have fixed the issue with the neighbor search page when selecting different components and types the graph is updated immediately.

The easiest way to fix this was to create 2 new states graphType and graphComponentArrayForm. These 2 states are passed into the graph component and are updated by the original type and componentArrayForm when the search button is clicked. This way the updated props are only passed to the graph when a search is executed but the changes are still updated in the original type and componentArrayForm.